### PR TITLE
Improvements to README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,19 @@ build out any helper methods if needed.
 
 #### Customer
 
-- `def __init__(self, name)`
+- 
+  ```python
+  def __init__(self, name)
+  ```
   - Customer should be initialized with a name 
 - 
-  ```
+  ```python
   @property
   def name(self)
   ```
     - Returns the customer's name, as a string
 - 
-  ```
+  ```python
   @name.setter
   def name(self, name)
   ```
@@ -79,16 +82,19 @@ build out any helper methods if needed.
 
 #### Coffee
 
-- `def __init__(self, name)`
+- 
+  ```python
+  def __init__(self, name)
+  ```
   - Coffees should be initialized with a name, as a string
 - 
-  ```
+  ```python
   @property
   def name(self)
   ```
     - Returns the coffee's name
 - 
-  ```
+  ```python
   @name.setter
   def name(self, name)
   ```
@@ -98,42 +104,45 @@ build out any helper methods if needed.
 
 #### Order
 
-- `def __init__(self, customer, coffee, price)`
+- 
+    ```python
+    def __init__(self, customer, coffee, price)
+    ```
   - Orders should be initialized with a customer, coffee, and a price (a number)
 - 
-  ```
+  ```python
   @property
   def price(self)
   ```
     - Returns the price for an order
 - 
-  ```
+  ```python
   @price.setter
   def price(self, price)
   ```
     - Price must be at least 1 and no greater than 10
     - `raise Exception` if setter fails
 - 
-  ```
+  ```python
   @property
   def customer(self)
   ```
     - Returns the customer object for that order
 - 
-  ```
+  ```python
   @customer.setter
   def customer(self, customer)
   ```
     - The argument `customer` must be of type `Customer`
     - `raise Exception` if setter fails
 - 
-  ```
+  ```python
   @property
   def coffee(self)
   ```
     - Returns the coffee object for that order
 - 
-  ```
+  ```python
   @coffee.setter
   def coffee(self, coffee)
   ```
@@ -145,7 +154,10 @@ build out any helper methods if needed.
 
 #### Coffee
 
-- `def orders(new_order=None)`
+- 
+  ```python
+  def orders(new_order=None)
+  ```
   - Adds `new_order` to `Coffee`'s 
   - Returns a list of all orders for that coffee
   - orders must be of type `Order`
@@ -158,12 +170,18 @@ build out any helper methods if needed.
 
 #### Customer
 
-- `def orders(new_order=None)`
+- 
+  ```python
+  def orders(new_order=None)
+  ```
   - Adds new orders to customer
   - Returns a list of all orders a customer has ordered
   - orders must be of type `Order`
   - _Will be called from `Order.__init__`_
-- `def coffees(new_coffee=None)`
+- 
+  ```python
+  def coffees(new_coffee=None)
+  ```
   - Adds new coffees to customer
   - Returns a list of all **unique** coffees a customer has ordered (i.e. the list will not contain the same coffee more than once).
     - The list must only contain objects of type `Coffee`
@@ -174,9 +192,15 @@ build out any helper methods if needed.
 
 #### Coffee
 
-- `def num_orders()`
+- 
+  ```python
+  def num_orders()
+  ```
   - Returns the total number of times that coffee has been ordered
-- `def average_price()`
+- 
+  ```python
+  def average_price()
+  ```
   - Returns the average price for a coffee based on its orders
   - Reminder: you can calculate the average by adding up all the orders prices and
     dividing by the number of orders

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ build out any helper methods if needed.
   ```python
   def orders(new_order=None)
   ```
-  - Adds `new_order` to `Coffee`'s 
+  - Adds `new_order` to `Coffee`'s orders
   - Returns a list of all orders for that coffee
   - orders must be of type `Order`
   - _Will be called from `Order.__init__`_

--- a/README.md
+++ b/README.md
@@ -59,100 +59,130 @@ build out any helper methods if needed.
 
 #### Customer
 
-- `Customer __init__(self, name)`
-  - Customer should be initialized with a name
-- `Customer property name`
-  - Return name
-  - Names must be of type `str`
-  - Names must be between 1 and 15 characters, inclusive
-  - if you are using exceptions, uncomment lines 26-27 and 34-38 in
-    `customer_test.py`.
+- `def __init__(self, name)`
+  - Customer should be initialized with a name 
+- 
+  ```
+  @property
+  def name(self)
+  ```
+    - Returns the customer's name, as a string
+- 
+  ```
+  @name.setter
+  def name(self, name)
+  ```
+    - Names must be of type `str`
+    - Names must be at least 1 character and at most 15 characters long
     - `raise Exception` if setter fails
+      
 
 #### Coffee
 
-- `Coffee __init__(self, name)`
+- `def __init__(self, name)`
   - Coffees should be initialized with a name, as a string
-- `Coffee property name`
-  - Returns the coffee's name
-  - Should not be able to change after the coffee is created
-  - _hint: `hasattr()`_
-  - if you are using exceptions, uncomment lines 24-25 in `coffee_test.py`.
+- 
+  ```
+  @property
+  def name(self)
+  ```
+    - Returns the coffee's name
+- 
+  ```
+  @name.setter
+  def name(self, name)
+  ```
+    - Should not be able to change after the coffee is created
+      - _hint: `hasattr()`_
     - `raise Exception` if setter fails
 
 #### Order
 
-- `Order __init__(self, customer, coffee, price)`
+- `def __init__(self, customer, coffee, price)`
   - Orders should be initialized with a customer, coffee, and a price (a number)
-- `Order property price`
-  - Returns the price for a coffee
-  - Price must be a number between 1 and 10, inclusive
+- 
+  ```
+  @property
+  def price(self)
+  ```
+    - Returns the price for an order
+- 
+  ```
+  @price.setter
+  def price(self, price)
+  ```
+    - Price must be at least 1 and no greater than 10
+    - `raise Exception` if setter fails
+- 
+  ```
+  @property
+  def customer(self)
+  ```
+    - Returns the customer object for that order
+- 
+  ```
+  @customer.setter
+  def customer(self, customer)
+  ```
+    - The argument `customer` must be of type `Customer`
+    - `raise Exception` if setter fails
+- 
+  ```
+  @property
+  def coffee(self)
+  ```
+    - Returns the coffee object for that order
+- 
+  ```
+  @coffee.setter
+  def coffee(self, coffee)
+  ```
+    - The argument `coffee` must be of type `Coffee` 
     - `raise Exception` if setter fails
 
-### Object Relationship Methods and Properties
+### Object Relationship Methods
 
-#### Order
-
-- `Order property customer`
-  - Returns the customer object for that order
-  - Must be of type `Customer`
-  - `raise Exception` if setter fails
-- `Order property coffee`
-  - Returns the coffee object for that order
-  - Must be of type `Coffee`
-  - `raise Exception` if setter fails
 
 #### Coffee
 
-- `Coffee orders(new_order=None)`
-  - Adds new orders to coffee
+- `def orders(new_order=None)`
+  - Adds `new_order` to `Coffee`'s 
   - Returns a list of all orders for that coffee
   - orders must be of type `Order`
   - _Will be called from `Order.__init__`_
-- `Coffee customers(new_customer=None)`
+- `def customers(new_customer=None)`
   - Adds new customers to coffee
-  - Returns a **unique** list of all customers who have ordered a particular coffee.
-  - Customers must be of type `Customer`
+  - Returns a list of all **unique** customers who have ordered a particular coffee (i.e. the list will not contain the same customer more than once).
+    - The list must only contain objects of type `Customer`
   - _Will be called from `Order.__init__`_
 
 #### Customer
 
-- `Customer orders(new_order=None)`
+- `def orders(new_order=None)`
   - Adds new orders to customer
   - Returns a list of all orders a customer has ordered
   - orders must be of type `Order`
   - _Will be called from `Order.__init__`_
-- `Customer coffees(new_coffee=None)`
+- `def coffees(new_coffee=None)`
   - Adds new coffees to customer
-  - Returns a **unique** list of all coffees a customer has ordered
-  - Coffees must be of type `Coffee`
+  - Returns a list of all **unique** coffees a customer has ordered (i.e. the list will not contain the same coffee more than once).
+    - The list must only contain objects of type `Coffee`
   - _Will be called from `Order.__init__`_
 
 ### Aggregate and Association Methods
 
 #### Customer
 
-- `Customer create_order(coffee, price)`
+- `def create_order(coffee, price)`
   - given a **coffee object** and a price(as an integer), creates a
     new order and associates it with that customer and coffee.
 
 #### Coffee
 
-- `Coffee num_orders()`
+- `def num_orders()`
   - Returns the total number of times that coffee has been ordered
-- `Coffee average_price()`
+- `def average_price()`
   - Returns the average price for a coffee based on its orders
   - Reminder: you can calculate the average by adding up all the orders prices and
     dividing by the number of orders
 
-### Bonus: For any invalid inputs raise an `Exception`.
-
-Uncomment the following lines in the test files:
-
-#### customer_test.py
-
-- lines 26-27 and 34-38
-
-#### coffee_test.py
-
-- lines 24-25

--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ build out any helper methods if needed.
   - Returns a list of all orders for that coffee
   - orders must be of type `Order`
   - _Will be called from `Order.__init__`_
-- `def customers(new_customer=None)`
+- 
+  ```python
+  def customers(new_customer=None)
+  ```
   - Adds new customers to coffee
   - Returns a list of all **unique** customers who have ordered a particular coffee (i.e. the list will not contain the same customer more than once).
     - The list must only contain objects of type `Customer`

--- a/README.md
+++ b/README.md
@@ -171,11 +171,6 @@ build out any helper methods if needed.
 
 ### Aggregate and Association Methods
 
-#### Customer
-
-- `def create_order(coffee, price)`
-  - given a **coffee object** and a price(as an integer), creates a
-    new order and associates it with that customer and coffee.
 
 #### Coffee
 

--- a/lib/classes/coffee.py
+++ b/lib/classes/coffee.py
@@ -1,6 +1,6 @@
 class Coffee:
     def __init__(self, name):
-        self.name = name
+        self.name = None
         
     def orders(self, new_order=None):
         from classes.order import Order
@@ -8,7 +8,7 @@ class Coffee:
     
     def customers(self, new_customer=None):
         from classes.customer import Customer
-        pass
+        return []
     
     def num_orders(self):
         pass

--- a/lib/classes/customer.py
+++ b/lib/classes/customer.py
@@ -1,11 +1,12 @@
 class Customer:
     def __init__(self, name):
-        self.name = name
+        self.name = None
+        
         
     def orders(self, new_order=None):
         from classes.order import Order
-        pass
+        return []
     
     def coffees(self, new_coffee=None):
         from classes.coffee import Coffee
-        pass
+        return []

--- a/lib/classes/order.py
+++ b/lib/classes/order.py
@@ -2,6 +2,6 @@
 class Order:
 
     def __init__(self, customer, coffee, price):
-        self.customer = customer
-        self.coffee = coffee
-        self.price = price
+        self.customer = None
+        self.coffee = None
+        self.price = None

--- a/lib/testing/coffee_test.py
+++ b/lib/testing/coffee_test.py
@@ -10,19 +10,19 @@ class TestCoffee:
     def test_has_name(self):
         '''coffee is initialized with a name'''
         coffee = Coffee("Mocha")
-        assert (coffee.name == "Mocha")
+        assert (coffee.name == "Mocha"), "The name attribute of Coffee was not set"
 
     def test_name_is_string(self):
         '''coffee is initialized with a name of type str'''
         coffee = Coffee("Mocha")
-        assert (isinstance(coffee.name, str))
+        assert (isinstance(coffee.name, str)), "The name attribute of Coffee was not initialized with a str"
 
     def test_name_setter(self):
         '''Cannot change the name of the coffee'''
         coffee = Coffee("Mocha")
 
-        # with pytest.raises(Exception):
-        #     coffee.name = "Peppermint Mocha"
+        with pytest.raises(Exception):
+            coffee.name = "Peppermint Mocha"
 
     def test_has_many_orders(self):
         '''coffee has many orders.'''
@@ -34,7 +34,7 @@ class TestCoffee:
         order_3 = Order(customer, coffee_2, 5)
 
         assert (len(coffee.orders()) == 2)
-        assert (order_1 in coffee.orders())
+        assert (order_1 in coffee.orders()), "order was not added to the coffee object's order list. Check that coffee.orders() is being called in Order.__init__"
         assert (order_2 in coffee.orders())
         assert (not order_3 in coffee.orders())
 
@@ -45,7 +45,7 @@ class TestCoffee:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee, 5)
 
-        assert (isinstance(coffee.orders()[0], Order))
+        assert (isinstance(coffee.orders()[0], Order)), "Coffee.orders() should return a list with objects of type Order" 
         assert (isinstance(coffee.orders()[1], Order))
 
     def test_has_many_customers(self):
@@ -57,7 +57,7 @@ class TestCoffee:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer_2, coffee, 5)
 
-        assert (customer in coffee.customers())
+        assert (customer in coffee.customers()), "customer was not added to the coffee object's customer list. Check that coffee.customers() is being called in Order.__init__"
         assert (customer_2 in coffee.customers())
 
     def test_has_unique_customers(self):
@@ -69,9 +69,10 @@ class TestCoffee:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer_2, coffee, 2)
         order_3 = Order(customer, coffee, 5)
-
-        assert (len(set(coffee.customers())) == len(coffee.customers()))
-        assert (len(coffee.customers()) == 2)
+        
+        assert (len(coffee.customers()) == 2), "the Coffee.customers() method did not return a list of 2 customers"
+        assert (len(set(coffee.customers())) == len(coffee.customers())), "Duplicate customers found in in Coffee"
+        
 
     def test_customers_of_type_customer(self):
         '''coffee customers are of type Customer'''
@@ -81,7 +82,7 @@ class TestCoffee:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer_2, coffee, 5)
 
-        assert (isinstance(coffee.customers()[0], Customer))
+        assert (isinstance(coffee.customers()[0], Customer)), "Coffee.customers() should return a list with objects of type Customer" 
         assert (isinstance(coffee.customers()[1], Customer))
 
     def test_get_number_of_orders(self):
@@ -91,7 +92,7 @@ class TestCoffee:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee, 5)
 
-        assert (coffee.num_orders() == 2)
+        assert (coffee.num_orders() == 2), "num_orders does not return the correct number. Check that Order.__init__ is calling coffee.orders()"
 
     def test_average_price(self):
         '''test average_price()'''
@@ -101,4 +102,4 @@ class TestCoffee:
         Order(customer, coffee, 2)
         Order(customer_2, coffee, 5)
 
-        assert (coffee.average_price() == 3.5)
+        assert (coffee.average_price() == 3.5), "average_price() computes incorrect result"

--- a/lib/testing/customer_test.py
+++ b/lib/testing/customer_test.py
@@ -10,32 +10,31 @@ class TestCustomer:
     def test_has_name(self):
         '''customer is initialized with name'''
         customer = Customer('Steve')
-        assert (customer.name == "Steve")
+        assert (customer.name == "Steve"), "name was not set in __init__"
 
-    def test_can_change_name(self):
-        '''customer name can be changed'''
-        customer = Customer('Steve')
-        customer.name = "Stove"
-        assert (customer.name == "Stove")
 
     def test_customer_name_is_str(self):
         '''customer name is a string'''
         customer = Customer('Steve')
-        assert (isinstance(customer.name, str))
+        assert (isinstance(customer.name, str)), "the name attribute was not assigned to a string"
 
-        # with pytest.raises(Exception):
-        #     customer.name = 1
+        with pytest.raises(Exception):
+            '''should raise Exception when name set to an int'''
+            customer.name = 1
 
     def test_customer_name_length(self):
         '''customer name is between 1 and 15 characters'''
         customer = Customer('Steve')
         assert (len(customer.name) == 5)
 
-        # with pytest.raises(Exception):
-        #     customer.name = "NameLongerThan15Characters"
+        with pytest.raises(Exception):
+            '''should raise Exception when name is longer than 15 characters'''
+            customer.name = "NameLongerThan15Characters"
+            
 
-        # with pytest.raises(Exception):
-        #     customer.name = ""
+        with pytest.raises(Exception):
+            '''should raise Exception when name is shorter than 1 character'''
+            customer.name = ""
 
     def test_has_many_orders(self):
         '''customer has many orders'''
@@ -58,7 +57,7 @@ class TestCustomer:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee, 5)
 
-        assert (isinstance(customer.orders()[0], Order))
+        assert (isinstance(customer.orders()[0], Order)), "Customer.orders() should return a list with objects of type Order" 
         assert (isinstance(customer.orders()[1], Order))
 
     def test_has_many_coffees(self):
@@ -70,7 +69,7 @@ class TestCustomer:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee_2, 5)
 
-        assert (coffee in customer.coffees())
+        assert (coffee in customer.coffees()), "coffee was not added to the Customer object's coffee list. Check that customer.coffees() is being called in Order.__init__"
         assert (coffee_2 in customer.coffees())
 
     def test_has_unique_coffees(self):
@@ -83,5 +82,6 @@ class TestCustomer:
         order_2 = Order(customer, coffee, 2)
         order_3 = Order(customer, coffee_2, 5)
 
-        assert (len(set(customer.coffees())) == len(customer.coffees()))
-        assert (len(customer.coffees()) == 2)
+        assert (len(customer.coffees()) == 2), "the Customer.coffees() method did not return a list of 2 coffees"
+        assert (len(set(customer.coffees())) == len(customer.coffees())), "Duplicate coffees found in in Order"
+        

--- a/lib/testing/order_test.py
+++ b/lib/testing/order_test.py
@@ -14,7 +14,7 @@ class TestOrders:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee, 5)
 
-        assert (order_1.price == 2)
+        assert (order_1.price == 2), "The price attribute of Order was not set"
         assert (order_2.price == 5)
 
     def test_has_a_customer(self):
@@ -25,7 +25,7 @@ class TestOrders:
         order_1 = Order(customer_1, coffee, 2)
         order_2 = Order(customer_2, coffee, 5)
 
-        assert (order_1.customer == customer_1)
+        assert (order_1.customer == customer_1), "The customer attribute of Order was not set"
         assert (order_2.customer == customer_2)
 
     def test_customer_of_type_customer(self):
@@ -35,18 +35,18 @@ class TestOrders:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee, 5)
 
-        assert (isinstance(order_1.customer, Customer))
+        assert (isinstance(order_1.customer, Customer)), "The customer attribute of Order was not initialized with a Customer object"
         assert (isinstance(order_2.customer, Customer))
 
     def test_has_a_coffee(self):
-        '''Review has a coffee.'''
+        '''Order has a coffee.'''
         coffee_1 = Coffee("Mocha")
         coffee_2 = Coffee("Peppermint Mocha")
         customer = Customer('Wayne')
         order_1 = Order(customer, coffee_1, 2)
         order_2 = Order(customer, coffee_2, 5)
 
-        assert (order_1.coffee == coffee_1)
+        assert (order_1.coffee == coffee_1), "The coffee attribute of Order was not set"
         assert (order_2.coffee == coffee_2)
 
     def test_coffee_of_type_coffee(self):
@@ -56,18 +56,7 @@ class TestOrders:
         order_1 = Order(customer, coffee, 2)
         order_2 = Order(customer, coffee, 5)
 
-        assert (isinstance(order_1.coffee, Coffee))
+        assert (isinstance(order_1.coffee, Coffee)), "The coffee attribute of Order was not initialized with a Coffee object"
         assert (isinstance(order_2.coffee, Coffee))
 
-    def test_get_all_orders(self):
-        '''test Order class all attribute'''
-        Order.all = []
-        coffee = Coffee("Mocha")
-        customer = Customer('Wayne')
-        customer_2 = Customer('Dima')
-        order_1 = Order(customer, coffee, 2)
-        order_2 = Order(customer_2, coffee, 5)
 
-        assert (len(Order.all) == 2)
-        assert (order_1 in Order.all)
-        assert (order_2 in Order.all)


### PR DESCRIPTION
In README
- explicitly use the @property decorator, as is used in the solution
- add complete method signatures in instructions
- add python syntax highlighting to signatures
- remove ambiguous instructions
  - Exceptions are now required everywhere instead of being bonus material in some places and not others
  -  Move all Order properties under one header instead of split between two
- remove instructions for untested method

In lib/classes
- assign None to attributes in constructors so that tests don't pass without students doing anything
- replace pass with return [] in coffees(), customers(), and orders() so that a type error is not thrown in the tests
In lib/testing
- remove test_can_change_name which always passes
- uncomment tests for raising exceptions
- remove test_get_all_orders, which was not described in the instructions
- add more descriptive error messages to asserts
