### PR TITLE
small fix, bonus test needs a float instead of int

### DIFF
--- a/lib/testing/customer_test.py
+++ b/lib/testing/customer_test.py
@@ -140,7 +140,7 @@ class TestCustomer:
     #     steve = Customer("Steve")
     #     dima = Customer("Dima")
     #     Order(steve, coffee, 2.0)
-    #     Order(steve, coffee, 4)
+    #     Order(steve, coffee, 4.0)
     #     Order(dima, coffee, 5.0)
     #     Order(dima, coffee, 2.0)
         


### PR DESCRIPTION
Bonus test has one Order created with a int which the instructions explicitly state need to be a float.